### PR TITLE
Passing host DNS to corectld.

### DIFF
--- a/src/functions.sh
+++ b/src/functions.sh
@@ -8,6 +8,11 @@ function pause(){
 }
 
 function printLocalDns(){
+    if nc -z localhost 53 1>/dev/null 2>&1
+    then
+        # port 53 is already bound, do not proceed:
+        return
+    fi
     local ALL_DNS='8.8.8.8:53,8.8.4.4:53'
     if [[ -r '/etc/resolv.conf' ]]
     then

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -6,3 +6,15 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 function pause(){
     read -p "$*"
 }
+
+function printLocalDns(){
+    local ALL_DNS='8.8.8.8:53,8.8.4.4:53'
+    if [[ -r '/etc/resolv.conf' ]]
+    then
+        for dns in $( grep '^nameserver' '/etc/resolv.conf' | awk '{ print $2 }' )
+        do
+            ALL_DNS="$dns:53,$ALL_DNS"
+        done
+    fi
+    echo "$ALL_DNS"
+}

--- a/src/start_corectld.command
+++ b/src/start_corectld.command
@@ -13,5 +13,10 @@ sudo -k > /dev/null 2>&1
 printf '%s\n' "$my_password" | sudo -Sv > /dev/null 2>&1
 
 # start corectld
-sudo nohup /usr/local/sbin/corectld start --user $(whoami) --recursive-nameservers "$( printLocalDns )"
-
+NAMESERVERS=""
+DNS="$( printLocalDns )"
+if [[ -n "$DNS" ]]
+then
+  NAMESERVERS="--recursive-nameservers '$DNS'"
+fi
+sudo nohup /usr/local/sbin/corectld start --user $(whoami) $NAMESERVERS

--- a/src/start_corectld.command
+++ b/src/start_corectld.command
@@ -13,5 +13,5 @@ sudo -k > /dev/null 2>&1
 printf '%s\n' "$my_password" | sudo -Sv > /dev/null 2>&1
 
 # start corectld
-sudo nohup /usr/local/sbin/corectld start --user $(whoami)
+sudo nohup /usr/local/sbin/corectld start --user $(whoami) --recursive-nameservers "$( printLocalDns )"
 


### PR DESCRIPTION
Needed change when there is internal registry instance in the office network and internal DNS is needed to resolve its hostname. Maybe that change will look better inside `corectld` itself, but will take me way more time to learn `go` and do it, while I want to use `CoreOS.app` already.
