### PR TITLE
Feat: Rephrase for a more relaxed notification style, see #42

### DIFF
--- a/src/copy_corectl_blobs.command
+++ b/src/copy_corectl_blobs.command
@@ -10,5 +10,5 @@ res_folder=$1
 mkdir ~/bin > /dev/null 2>&1
 
 # copy blobs
-echo "Copying files ..."
+echo "Copying files…"
 cp -f "${res_folder}"/* ~/bin/

--- a/src/corectl/AppDelegate.swift
+++ b/src/corectl/AppDelegate.swift
@@ -66,7 +66,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         else {
             //
             let alert: NSAlert = NSAlert()
-            alert.messageText = "Restarting Corectld server will halt all your running VMs !!!"
+            alert.messageText = "Restarting Corectld server will halt all your running VMs."
             alert.informativeText = "Are you sure you want to do that?"
             alert.alertStyle = NSAlertStyle.warning
             alert.addButton(withTitle: "OK")
@@ -85,7 +85,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // send a notification on to the screen
         let notification: NSUserNotification = NSUserNotification()
         notification.title = "Corectl"
-        notification.informativeText = "Updates for Corectl App will be checked"
+        notification.informativeText = "Updates for Corectl App will be checked…"
         NSUserNotificationCenter.default.deliver(notification)
         
         // run check function
@@ -97,7 +97,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // send a notification on to the screen
         let notification: NSUserNotification = NSUserNotification()
         notification.title = "Corectl"
-        notification.informativeText = "Updates for Corectl tools will be checked"
+        notification.informativeText = "Updates for Corectl tools will be checked…"
         NSUserNotificationCenter.default.deliver(notification)
         
         // run check function
@@ -111,7 +111,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // send a notification on to the screen
         let notification: NSUserNotification = NSUserNotification()
         notification.title = "Corectl"
-        notification.informativeText = "CoreOS Alpha ISO image will be updated"
+        notification.informativeText = "CoreOS Alpha ISO image will be updated…"
         NSUserNotificationCenter.default.deliver(notification)
         
         // run the script
@@ -122,7 +122,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // send a notification on to the screen
         let notification: NSUserNotification = NSUserNotification()
         notification.title = "Corectl"
-        notification.informativeText = "CoreOS Beta ISO image will be updated"
+        notification.informativeText = "CoreOS Beta ISO image will be updated…"
         NSUserNotificationCenter.default.deliver(notification)
         
         // run the script
@@ -133,7 +133,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // send a notification on to the screen
         let notification: NSUserNotification = NSUserNotification()
         notification.title = "Corectl"
-        notification.informativeText = "CoreOS Stable ISO image will be updated"
+        notification.informativeText = "CoreOS Stable ISO image will be updated…"
         NSUserNotificationCenter.default.deliver(notification)
         
         // run the script
@@ -146,7 +146,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBAction func About(_ sender: NSMenuItem) {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")as? String
         let mText: String = "Corectl for macOS v" + version!
-        let infoText: String = "It is a simple wrapper around the \"corectld\" server, allows to have a control via the Status Bar App !!!"
+        let infoText: String = "A simple wrapper around the \"corectld\" server. Allows to have control your server via the Status Bar App."
         displayWithMessage(mText, infoText: infoText)
     }
     
@@ -155,7 +155,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBAction func Quit(_ sender: NSMenuItem) {
         //
         let alert: NSAlert = NSAlert()
-        alert.messageText = "Quitting App will halt all your running VMs !!!"
+        alert.messageText = "Quitting the Corectl App will halt all your running VMs."
         alert.informativeText = "Are you sure you want to close the App?"
         alert.alertStyle = NSAlertStyle.warning
         alert.addButton(withTitle: "OK")
@@ -164,7 +164,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // if OK clicked 
             // send a notification on to the screen
             let notification: NSUserNotification = NSUserNotification()
-            notification.title = "Quitting Corectl App"
+            notification.title = "Quitting Corectl App…"
             NSUserNotificationCenter.default.deliver(notification)
 
             // stop corectld server
@@ -230,8 +230,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // check resourcePath and exit the App if it runs from the dmg
         if resoucesPathFromApp.isEqual(dmgPath) {
             // show alert message
-            let mText: String = "\("Corectl App cannot be started from DMG !!!")"
-            let infoText: String = "Please copy App to your Applications folder ..."
+            let mText: String = "\("Corectl App cannot be started from DMG.")"
+            let infoText: String = "Please copy the App to your Applications folder."
             displayWithMessage(mText, infoText: infoText)
             // exiting App
             NSApplication.shared().terminate(self)
@@ -249,11 +249,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         //
         if (status == "yes"){
             let menuItem : NSStatusItem = statusItem
-            menuItem.menu?.item(withTag: 1)?.title = "Server is running"
+            menuItem.menu?.item(withTag: 1)?.title = "Server status: Running"
         }
         else {
             let menuItem : NSStatusItem = statusItem
-            menuItem.menu?.item(withTag: 1)?.title = "Server is Off"
+            menuItem.menu?.item(withTag: 1)?.title = "Server status: Off"
         }
     }
     
@@ -282,7 +282,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         else {
             // update menu item
             let menuItem : NSStatusItem = statusItem
-            menuItem.menu?.item(withTag: 10)?.title = " Active VMs: 0"
+            menuItem.menu?.item(withTag: 10)?.title = "No Active VMs"
         }
     }
 

--- a/src/corectl/ServerControl.swift
+++ b/src/corectl/ServerControl.swift
@@ -15,7 +15,7 @@ func ServerStart() {
     
     // send an alert about the user password
     let mText: String = "Corectl for macOS"
-    let infoText: String = "You will be asked to type your \"user\" password, needed to start \"corectld\" server !!!"
+    let infoText: String = "You will be asked to type your \"user\" password to start the \"Corectld\" server."
     displayWithMessage(mText, infoText: infoText)
     
     //
@@ -38,14 +38,14 @@ func ServerStart() {
         //
         if (status == "no"){
             let menuItem : NSStatusItem = statusItem
-            menuItem.menu?.item(withTag: 1)?.title = "Server is Off"
+            menuItem.menu?.item(withTag: 1)?.title = "Server status: Off"
             // display the error message
             let mText: String = "Corectl for macOS"
-            let infoText: String = "Cannot start the \"corectld server\" !!!"
+            let infoText: String = "Can not start the \"Corectl server\"."
             displayWithMessage(mText, infoText: infoText)
         }
         else {
-            menuItem.menu?.item(withTag: 1)?.title = "Server is running"
+            menuItem.menu?.item(withTag: 1)?.title = "Server status: Running"
             menuItem.menu?.item(withTag: 1)?.state = NSOnState
             //
             let script = Bundle.main.resourcePath! + "/check_corectld_version.command"
@@ -63,7 +63,7 @@ func ServerStop() {
     let menuItem : NSStatusItem = statusItem
     
     // show notification on to screen
-    //notifyUserWithTitle("Corectl App", text: "All running VMs will be stopped !!!")
+    //notifyUserWithTitle("Corectl App", text: "All running VMs will be stopped.")
     
     // stop corectld server
     let task = Process()
@@ -73,7 +73,7 @@ func ServerStop() {
     task.waitUntilExit()
     
     //
-    menuItem.menu?.item(withTag: 1)?.title = "Server is off"
+    menuItem.menu?.item(withTag: 1)?.title = "Server status: Off"
     menuItem.menu?.item(withTag: 1)?.state = NSOffState
 }
 
@@ -84,22 +84,22 @@ func RestartServer() {
     let menuItem : NSStatusItem = statusItem
     
     // send a notification on to the screen
-    print("Restarting corectld server")
+    print("Restarting Corectl server")
     let notification: NSUserNotification = NSUserNotification()
     notification.title = "Restarting corectld server"
     NSUserNotificationCenter.default.deliver(notification)
     
     // stop corectld server
-    menuItem.menu?.item(withTag: 1)?.title = "Server is stopping"
+    menuItem.menu?.item(withTag: 1)?.title = "Server is stopping…"
     ServerStop()
     
     // start corectld server
-    menuItem.menu?.item(withTag: 1)?.title = "Server is starting"
+    menuItem.menu?.item(withTag: 1)?.title = "Server is starting…"
     ServerStart()
     
     //
     menuItem.menu?.item(withTag: 3)?.title = "Check for App updates"
-    menuItem.menu?.item(withTag: 4)?.title = "Check for corectl updates"
+    menuItem.menu?.item(withTag: 4)?.title = "Check for Corectl updates"
 }
 
 

--- a/src/corectl/Updates.swift
+++ b/src/corectl/Updates.swift
@@ -15,10 +15,10 @@ func check_for_corectl_app_github(_ showPopUp:String?=nil, runViaUpdateMenu:Stri
     //
     let script = Bundle.main.resourcePath! + "/check_corectl_app_version.command"
     let latest_app_version = shell(script, arguments: [])
-    print("latest app version: " + latest_app_version)
+    print("Latest app version: " + latest_app_version)
     //
     if (latest_app_version == "" ) {
-        NSLog("Cannot check latest version on Github, must be API limit was reached or other Github tecnnical issues !!!")
+        NSLog("We can not check the latest version on Github. There was either an API limit reached, or Github has technical issues.")
         return
     }
     //
@@ -30,7 +30,7 @@ func check_for_corectl_app_github(_ showPopUp:String?=nil, runViaUpdateMenu:Stri
         // then show popup on the screeen
         if (runViaUpdateMenu == "yes") {
             let mText: String = "Corectl App for macOS"
-            let infoText: String = "You are up-to-date ..."
+            let infoText: String = "You are up-to-date!"
             displayWithMessage(mText, infoText: infoText)
         }
         else {
@@ -47,7 +47,7 @@ func check_for_corectl_app_github(_ showPopUp:String?=nil, runViaUpdateMenu:Stri
         }
         else {
             let menuItem : NSStatusItem = statusItem
-            menuItem.menu?.item(withTag: 3)?.title = "Download App updates..."
+            menuItem.menu?.item(withTag: 3)?.title = "Download App updates"
         }
     }
 }
@@ -55,7 +55,7 @@ func check_for_corectl_app_github(_ showPopUp:String?=nil, runViaUpdateMenu:Stri
 func download_corectl_app_github() {
     // show popup on the screen
     let alert: NSAlert = NSAlert()
-    alert.messageText = "There is a new version of Corectl App available !!!"
+    alert.messageText = "There is a new version of the Corectl App available"
     alert.informativeText = "Open download URL in your browser?"
     alert.alertStyle = NSAlertStyle.warning
     alert.addButton(withTitle: "OK")
@@ -89,7 +89,7 @@ func check_for_corectl_blobs_github(_ showPopUp:String?=nil, runViaUpdateMenu:St
         }
         else {
             let menuItem : NSStatusItem = statusItem
-            menuItem.menu?.item(withTag: 4)?.title = "Download corectl updates..."
+            menuItem.menu?.item(withTag: 4)?.title = "Downloading Corectl updates…"
         }
     }
     else {
@@ -100,7 +100,7 @@ func check_for_corectl_blobs_github(_ showPopUp:String?=nil, runViaUpdateMenu:St
         }
         else {
             let menuItem : NSStatusItem = statusItem
-            menuItem.menu?.item(withTag: 4)?.title = "Check for corectl updates"
+            menuItem.menu?.item(withTag: 4)?.title = "Check for Corectl updates"
         }
     }
 }
@@ -108,7 +108,7 @@ func check_for_corectl_blobs_github(_ showPopUp:String?=nil, runViaUpdateMenu:St
 // download corectl blobs
 func download_corectl_blobs_github(_ runViaUpdateMenu:String?=nil) {
     let alert: NSAlert = NSAlert()
-    alert.messageText = "There is a new version of Corectld server available !!!"
+    alert.messageText = "There is a new version of the Corectld server available"
     alert.informativeText = "Do you want to download it?"
     alert.alertStyle = NSAlertStyle.warning
     alert.addButton(withTitle: "OK")
@@ -129,12 +129,12 @@ func download_corectl_blobs_github(_ runViaUpdateMenu:String?=nil) {
 //            }
             // restore menu item
 //            let menuItem : NSStatusItem = statusItem
-//            menuItem.menu?.itemWithTag(4)?.title = "Check for corectl updates"
+//            menuItem.menu?.itemWithTag(4)?.title = "Check for Corectl updates"
 //        }
     }
     else {
         let menuItem : NSStatusItem = statusItem
-        menuItem.menu?.item(withTag: 4)?.title = "Download corectl updates..."
+        menuItem.menu?.item(withTag: 4)?.title = "Downloading Corectl updates…"
     }
 }
 

--- a/src/fetch_latest_iso_stable.command
+++ b/src/fetch_latest_iso_stable.command
@@ -9,7 +9,7 @@ source "${DIR}"/functions.sh
 CHANNEL=stable
 
 echo " "
-echo "Fetching lastest CoreOS $CHANNEL channel ISO ..."
+echo "Fetching lastest CoreOS $CHANNEL channel ISO…"
 echo " "
 #
 ~/bin/corectl pull --channel="$CHANNEL" 2>&1 | tee ~/.coreos/tmp/check_channel
@@ -17,13 +17,13 @@ CHECK_CHANNEL=$(cat ~/.coreos/tmp/check_channel | grep "downloading" | awk '{pri
 #
 if [[ "$CHECK_CHANNEL" == "downloading" ]]; then
     echo " "
-    echo "You need to reload your VMs to use the lastest version !!! "
+    echo "You will need to reload your VMs to use the lastest version."
     rm -f ~/.coreos/tmp/check_channel
 else
-    echo "You have the latest ISO already ..."
+    echo "You already have the latest CoreOS ISO."
 fi
 
 echo " "
-pause 'Press [Enter] key to continue...'
+pause 'Please press [Enter] to continue.'
 
 exit 0

--- a/src/get_go_binaries/corectl_download_latest.sh
+++ b/src/get_go_binaries/corectl_download_latest.sh
@@ -20,7 +20,7 @@ chmod +x *
 
 cd $current_folder
 # copy blobs
-echo "Copying files ..."
+echo "Copying files…"
 cp -f bin/* ../bin
 
 #

--- a/src/start_docker_registry.command
+++ b/src/start_docker_registry.command
@@ -12,6 +12,6 @@ kill $(ps aux | grep "[r]egistry serve config.yml" | awk {'print $2'}) >/dev/nul
 sleep 1
 
 # start registry
-echo "Starting Docker Registry v2 on 192.168.64.1:5000 ..."
+echo "Starting Docker Registry v2 on 192.168.64.1:5000…"
 cd ~/.coreos/registry
 nohup "${res_folder}"/registry/registry serve config.yml >/dev/null 2>&1 &

--- a/src/update_corectl_blobs.command
+++ b/src/update_corectl_blobs.command
@@ -20,7 +20,7 @@ rm -f corectl.tar.gz
 chmod +x *
 
 # copy blobs
-echo "Copying files to ~/bin ..."
+echo "Copying files to ~/bin …"
 cp -f * ~/bin/ > /dev/null 2>&1
 
 #
@@ -28,7 +28,7 @@ cd ~/
 rm -fr ~/tmp/corectl > /dev/null 2>&1
 
 #
-echo "Download has finished !!!"
+echo "The download has finished."
 echo " "
 
 # check if corectld is running
@@ -36,21 +36,22 @@ CHECK_SERVER_STATUS=$(~/bin/corectld status 2>&1 | grep "Uptime:")
 
 if [[ "$CHECK_SERVER_STATUS" == "" ]]; then
     # corectld is not running
-    echo "Corectld is updated to latest version ..."
+    echo "Corectld is updated to latest version."
 else
     # check for active VMs
     vms=$(~/bin/corectld status | grep "Active VMs:" | awk '{print $3}')
     if [[ "$vms" -ne "0" ]]; then
     # active VMs
-        echo "You need to restart 'corectld' server via menu, but Halt all your VMs first, as you have $vms running !!! "
+        echo "You have $vms VMs running. Please stop them."
+        echo "Then restart the 'corectld' server via the menu."
     else
         # no vms
-        echo "You need to restart 'corectld' server via menu !!! "
+        echo "Please restart the 'corectld' server via the menu."
     fi
 fi
 
 echo " "
-pause 'Press [Enter] key to continue...'
+pause 'Please press [Enter] to continue.'
 
 exit 0
 


### PR DESCRIPTION
* Removes the `!!!` shouting, 
* Removes unnecessary space usage, 
* Tries to to use _Corectl_ instead of the _corectl_ variant found here and there
* Some rephrasing
* Be nicer: Say _please_
* Do not panic – we are dealing with developers (who do not read anyway) – when a VM goes down, then it goes dow
* A little bit of grammar and such things here and there
* Consolidates; _Server is Off_ and _Server is running_ into _Server status: Off/Running_
* Replaces _Active VMs: 0_ with _No Active VMs_
* … minor things

Hope you like it.